### PR TITLE
[SP][PCA] - GameRoundResult

### DIFF
--- a/Pca/Exceptions/RefundTransactionNotFoundException.php
+++ b/Pca/Exceptions/RefundTransactionNotFoundException.php
@@ -3,17 +3,14 @@
 namespace Providers\Pca\Exceptions;
 
 use Exception;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 
 class RefundTransactionNotFoundException extends Exception
 {
-    public function __construct(private Request $request) {}
-
     public function render(): JsonResponse
     {
         return response()->json([
-            'requestId' => $this->request->requestId,
+            'requestId' => request()->input('requestId'),
             'error' => [
                 'code' => 'ERR_NO_BET'
             ]

--- a/Pca/Exceptions/TransactionNotFoundException.php
+++ b/Pca/Exceptions/TransactionNotFoundException.php
@@ -3,17 +3,14 @@
 namespace Providers\Pca\Exceptions;
 
 use Exception;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 
 class TransactionNotFoundException extends Exception
 {
-    public function __construct(private Request $request) {}
-
     public function render(): JsonResponse
     {
         return response()->json([
-            'requestId' => $this->request->requestId,
+            'requestId' => request()->input('requestId'),
             'error' => [
                 'code' => 'INTERNAL_ERROR'
             ]

--- a/Pca/PcaRepository.php
+++ b/Pca/PcaRepository.php
@@ -46,6 +46,13 @@ class PcaRepository
             ->first();
     }
 
+    public function getTransactionByRefID(string $refID): ?object
+    {
+        return DB::table('pca.reports')
+            ->where('ref_id', $refID)
+            ->first();
+    }
+
     public function getPlayGameByPlayIDToken(string $playID, string $token): ?object
     {
         return DB::table('pca.playgame')
@@ -63,45 +70,17 @@ class PcaRepository
             ->delete();
     }
 
-    public function getTransactionByTransactionIDRefID(string $transactionID, string $refID): ?object
+    public function getBetTransactionByRefID(string $refID): ?object
     {
         return DB::table('pca.reports')
-            ->where('bet_id', $transactionID)
             ->where('ref_id', $refID)
             ->first();
     }
 
-    public function getTransactionByBetID(string $betID): ?object
+    public function getBetTransactionByBetID(string $betID): ?object
     {
         return DB::table('pca.reports')
             ->where('bet_id', $betID)
-            ->first();
-    }
-
-    public function getBetTransactionByTransactionID(string $transactionID): ?object
-    {
-        return DB::table('pca.reports')
-            ->where('bet_id', $transactionID)
-            ->where('status', 'WAGER')
-            ->first();
-    }
-
-    public function getBetTransactionByTransactionIDRefID(string $transactionID, string $refID): ?object
-    {
-        return DB::table('pca.reports')
-            ->selectRaw('wager_amount AS bet_amount, bet_time AS created_at, ref_id')
-            ->where('bet_id', $transactionID)
-            ->where('status', 'WAGER')
-            ->where('ref_id', $refID)
-            ->first();
-    }
-
-    public function getRefundTransactionByTransactionIDRefID(string $transactionID, string $refID): ?object
-    {
-        return DB::table('pca.reports')
-            ->where('bet_id', $transactionID)
-            ->where('status', 'REFUND')
-            ->where('ref_id', "R-{$refID}")
             ->first();
     }
 
@@ -129,60 +108,6 @@ class PcaRepository
                 'bet_time' => $betTime,
                 'status' => $status,
                 'ref_id' => $refID
-            ]);
-    }
-
-    public function createSettleTransaction(object $player, Request $request, string $settleTime): void
-    {
-        DB::connection('pgsql_write')
-            ->table('pca.reports')
-            ->insert([
-                'play_id' => $player->play_id,
-                'currency' => $player->currency,
-                'game_code' => $request->gameCodeName,
-                'bet_choice' => '-',
-                'bet_id' => $request->gameRoundCode,
-                'wager_amount' => 0,
-                'payout_amount' => (float) $request->pay['amount'],
-                'bet_time' => $settleTime,
-                'status' => 'PAYOUT',
-                'ref_id' => $request->pay['transactionCode']
-            ]);
-    }
-
-    public function createLoseTransaction(object $player, Request $request): void
-    {
-        DB::connection('pgsql_write')
-            ->table('pca.reports')
-            ->insert([
-                'play_id' => $player->play_id,
-                'currency' => $player->currency,
-                'game_code' => $request->gameCodeName,
-                'bet_choice' => '-',
-                'bet_id' => $request->gameRoundCode,
-                'wager_amount' => 0,
-                'payout_amount' => 0,
-                'bet_time' => Carbon::now()->setTimezone('GMT+8')->format('Y-m-d H:i:s'),
-                'status' => 'PAYOUT',
-                'ref_id' => "L-{$request->requestId}"
-            ]);
-    }
-
-    public function createRefundTransaction(object $player, Request $request, string $refundTime): void
-    {
-        DB::connection('pgsql_write')
-            ->table('pca.reports')
-            ->insert([
-                'play_id' => $player->play_id,
-                'currency' => $player->currency,
-                'game_code' => $request->gameCodeName,
-                'bet_choice' => '-',
-                'bet_id' => $request->gameRoundCode,
-                'wager_amount' => $request->pay['amount'],
-                'payout_amount' => $request->pay['amount'],
-                'bet_time' => $refundTime,
-                'status' => 'REFUND',
-                'ref_id' => "R-{$request->pay['relatedTransactionCode']}"
             ]);
     }
 }

--- a/Pca/PcaService.php
+++ b/Pca/PcaService.php
@@ -208,7 +208,7 @@ class PcaService
         $betTransaction = $this->repository->getBetTransactionByRefID(refID: $request->gameRoundCode);
 
         if (is_null($betTransaction) === true)
-            throw new ProviderTransactionNotFoundException(request: $request);
+            throw new ProviderTransactionNotFoundException;
 
         $betID = is_null($request->pay) === true ? "L-{$request->requestId}" : $request->pay['transactionCode'];
 
@@ -295,7 +295,7 @@ class PcaService
         );
 
         if (is_null($betTransaction) === true)
-            throw new RefundTransactionNotFoundException(request: $request);
+            throw new RefundTransactionNotFoundException;
 
         $refundTransaction = $this->repository->getTransactionByRefID(
             refID: $request->pay['relatedTransactionCode']

--- a/Pca/PcaService.php
+++ b/Pca/PcaService.php
@@ -323,17 +323,25 @@ class PcaService
                 betTime: $transactionDate,
                 status: 'REFUND',
                 refID: $request->pay['relatedTransactionCode']
-            );  
+            );
 
-            $walletResponse = $this->wallet->resettle(
+            $report = $this->report->makeCasinoReport(
+                trxID: $request->pay['transactionCode'],
+                gameCode: $request->gameCodeName,
+                betTime: $transactionDate,
+                betChoice: '-',
+                result: '-'
+            );
+
+            $walletResponse = $this->wallet->wagerAndPayout(
                 credentials: $credentials,
                 playID: $player->play_id,
                 currency: $player->currency,
-                transactionID: "resettle-{$request->pay['transactionCode']}",
-                amount: (float) $request->pay['amount'],
-                betID: $request->pay['transactionCode'],
-                settledTransactionID: "wager-{$request->pay['transactionCode']}",
-                betTime: $transactionDate
+                wagerTransactionID: "wagerPayout-{$request->pay['transactionCode']}",
+                wagerAmount: 0,
+                payoutTransactionID: "wagerPayout-{$request->pay['transactionCode']}",
+                payoutAmount: (float) $request->pay['amount'],
+                report: $report
             );
 
             if ($walletResponse['status_code'] !== 2100)

--- a/Pca/tests/Feature/GameProvider/PcaRefundTest.php
+++ b/Pca/tests/Feature/GameProvider/PcaRefundTest.php
@@ -20,27 +20,27 @@ class PcaRefundTest extends TestCase
     public function test_refund_validRequest_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '1234567890',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '1234567890'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
@@ -91,16 +91,16 @@ class PcaRefundTest extends TestCase
         $response->assertStatus(200);
 
         $this->assertDatabaseHas('pca.reports', [
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794157',
             'wager_amount' => 10,
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 08:00:00',
             'status' => 'REFUND',
-            'ref_id' => 'R-1234567890'
+            'ref_id' => '1234567890'
         ]);
     }
 
@@ -109,7 +109,7 @@ class PcaRefundTest extends TestCase
     {
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
@@ -168,7 +168,7 @@ class PcaRefundTest extends TestCase
     {
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
@@ -247,14 +247,14 @@ class PcaRefundTest extends TestCase
     public function test_refund_transactionNotFound_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
@@ -293,40 +293,40 @@ class PcaRefundTest extends TestCase
     public function test_refund_transactionAlreadyExist_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '1234567890',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '1234567890'
+            'ref_id' => '27281386'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794157',
             'wager_amount' => 10,
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 08:00:00',
             'status' => 'REFUND',
-            'ref_id' => 'R-1234567890'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
@@ -380,27 +380,27 @@ class PcaRefundTest extends TestCase
     public function test_refund_invalidWalletResponse_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '1234567890',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '1234567890'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
@@ -447,16 +447,16 @@ class PcaRefundTest extends TestCase
         $response->assertStatus(200);
 
         $this->assertDatabaseMissing('pca.reports', [
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794157',
             'wager_amount' => 10,
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 08:00:00',
             'status' => 'REFUND',
-            'ref_id' => 'R-1234567890'
+            'ref_id' => '1234567890'
         ]);
     }
 
@@ -464,27 +464,27 @@ class PcaRefundTest extends TestCase
     public function test_refund_validDataGiven_expectedData($wallet, $expectedBalance)
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '1234567890',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '1234567890'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PCAUCN_PLAYER001',
+            'username' => 'PCAUCN_TESTPLAYID',
             'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [

--- a/Pca/tests/Feature/GameProvider/PcaRefundTest.php
+++ b/Pca/tests/Feature/GameProvider/PcaRefundTest.php
@@ -321,7 +321,7 @@ class PcaRefundTest extends TestCase
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 08:00:00',
             'status' => 'REFUND',
-            'ref_id' => '27281386'
+            'ref_id' => '1234567890'
         ]);
 
         $payload = [
@@ -351,11 +351,11 @@ class PcaRefundTest extends TestCase
         ];
 
         $wallet = new class extends TestWallet {
-            public function Resettle(IWalletCredentials $credentials, string $playID, string $currency, string $transactionID, float $amount, string $betID, string $settledTransactionID, string $betTime): array
+            public function Balance(IWalletCredentials $credentials, string $playID): array
             {
                 return [
-                    'credit_after' => 1010.0,
-                    'status_code' => 2102
+                    'credit' => 1010.0,
+                    'status_code' => 2100
                 ];
             }
         };

--- a/Pca/tests/Feature/GameProvider/PcaRefundTest.php
+++ b/Pca/tests/Feature/GameProvider/PcaRefundTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 use App\Libraries\Wallet\V2\TestWallet;
 use App\Contracts\V2\IWalletCredentials;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Wallet\V1\ProvSys\Transfer\Report;
 
 class PcaRefundTest extends TestCase
 {
@@ -65,12 +66,13 @@ class PcaRefundTest extends TestCase
         ];
 
         $wallet = new class extends TestWallet {
-            public function Resettle(IWalletCredentials $credentials, string $playID, string $currency, string $transactionID, float $amount, string $betID, string $settledTransactionID, string $betTime): array
+            public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
             {
                 return [
                     'credit_after' => 1010.0,
                     'status_code' => 2100
                 ];
+                  
             }
         };
 
@@ -425,7 +427,7 @@ class PcaRefundTest extends TestCase
         ];
 
         $wallet = new class extends TestWallet {
-            public function Resettle(IWalletCredentials $credentials, string $playID, string $currency, string $transactionID, float $amount, string $betID, string $settledTransactionID, string $betTime): array
+            public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
             {
                 return [
                     'status_code' => 'invalid'
@@ -529,49 +531,49 @@ class PcaRefundTest extends TestCase
     {
         return [
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 123, 'status_code' => 2100];
                 }
             }, '123.00'],
 
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 123.456789, 'status_code' => 2100];
                 }
             }, '123.45'],
 
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 123.409987, 'status_code' => 2100];
                 }
             }, '123.40'],
 
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 123.000, 'status_code' => 2100];
                 }
             }, '123.00'],
 
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 123.000009, 'status_code' => 2100];
                 }
             }, '123.00'],
 
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 100.000, 'status_code' => 2100];
                 }
             }, '100.00'],
 
             [new class extends TestWallet {
-                public function Resettle(IWalletCredentials $credentials,  string $playID, string $currency,  string $transactionID,  float $amount,  string $betID,  string $settledTransactionID,  string $betTime): array
+                public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
                 {
                     return ['credit_after' => 100, 'status_code' => 2100];
                 }

--- a/Pca/tests/Feature/GameProvider/PcaSettleTest.php
+++ b/Pca/tests/Feature/GameProvider/PcaSettleTest.php
@@ -22,28 +22,28 @@ class PcaSettleTest extends TestCase
     public function test_settle_validRequestNoWin_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794150',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '8366794150'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'jackpot' => [
                 'contributionAmount' => '0.0123456789123456',
@@ -87,44 +87,44 @@ class PcaSettleTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('pca.reports', [
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => 'L-b0f09415-8eec-493d-8e70-c0659b972653',
             'wager_amount' => 0,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'PAYOUT',
-            'ref_id' => 'L-b0f09415-8eec-493d-8e70-c0659b972653'
+            'ref_id' => '27281386'
         ]);
     }
 
     public function test_settle_validRequestWithWin_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794150',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '8366794150'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -173,16 +173,16 @@ class PcaSettleTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('pca.reports', [
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794157',
             'wager_amount' => 0,
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 08:00:03',
             'status' => 'PAYOUT',
-            'ref_id' => '8366794157'
+            'ref_id' => '27281386'
         ]);
     }
 
@@ -191,8 +191,8 @@ class PcaSettleTest extends TestCase
     {
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'jackpot' => [
                 'contributionAmount' => '0.0123456789123456',
@@ -236,8 +236,8 @@ class PcaSettleTest extends TestCase
     {
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -294,8 +294,8 @@ class PcaSettleTest extends TestCase
     {
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -334,7 +334,7 @@ class PcaSettleTest extends TestCase
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
             'username' => 'invalidUsername',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -371,15 +371,15 @@ class PcaSettleTest extends TestCase
     public function test_settle_NoBetTransactionFound_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -416,41 +416,41 @@ class PcaSettleTest extends TestCase
     public function test_settle_transactionAlreadyExistWithoutWin_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794150',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '8366794150'
+            'ref_id' => '27281386'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => 'L-b0f09415-8eec-493d-8e70-c0659b972653',
             'wager_amount' => 0,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'PAYOUT',
-            'ref_id' => 'L-b0f09415-8eec-493d-8e70-c0659b972653'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'jackpot' => [
                 'contributionAmount' => '0.0123456789123456',
@@ -497,41 +497,41 @@ class PcaSettleTest extends TestCase
     public function test_settle_transactionAlreadyExistWithWin_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794150',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 08:00:00',
             'status' => 'WAGER',
-            'ref_id' => '8366794150'
+            'ref_id' => '27281386'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794157',
             'wager_amount' => 0,
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 08:00:03',
             'status' => 'PAYOUT',
-            'ref_id' => '8366794157'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -583,28 +583,28 @@ class PcaSettleTest extends TestCase
     public function test_settle_invalidWalletResponse_expectedData()
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794150',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '8366794150'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',
@@ -649,16 +649,16 @@ class PcaSettleTest extends TestCase
         ]);
 
         $this->assertDatabaseMissing('pca.reports', [
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794157',
             'wager_amount' => 0,
             'payout_amount' => 10,
             'bet_time' => '2024-01-01 00:00:03',
             'status' => 'PAYOUT',
-            'ref_id' => '8366794157'
+            'ref_id' => '27281386'
         ]);
     }
 
@@ -666,28 +666,28 @@ class PcaSettleTest extends TestCase
     public function test_settle_validDataGiven_expectedData($wallet, $expectedBalance)
     {
         DB::table('pca.players')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'username' => 'testPlayer',
             'currency' => 'IDR'
         ]);
 
         DB::table('pca.reports')->insert([
-            'play_id' => 'player001',
+            'play_id' => 'testplayid',
             'currency' => 'IDR',
             'game_code' => 'aogs',
             'bet_choice' => '-',
-            'bet_id' => '27281386',
+            'bet_id' => '8366794150',
             'wager_amount' => 10,
             'payout_amount' => 0,
             'bet_time' => '2024-01-01 00:00:00',
             'status' => 'WAGER',
-            'ref_id' => '8366794150'
+            'ref_id' => '27281386'
         ]);
 
         $payload = [
             'requestId' => 'b0f09415-8eec-493d-8e70-c0659b972653',
-            'username' => 'PLAUC_PLAYER001',
-            'externalToken' => 'PLAUC_TOKEN88888888',
+            'username' => 'PCAUCN_TESTPLAYID',
+            'externalToken' => 'PCAUCN_TOKEN88888888',
             'gameRoundCode' => '27281386',
             'pay' => [
                 'transactionCode' => '8366794157',

--- a/Pca/tests/Feature/GameProvider/PcaSettleTest.php
+++ b/Pca/tests/Feature/GameProvider/PcaSettleTest.php
@@ -471,7 +471,7 @@ class PcaSettleTest extends TestCase
             public function Balance(IWalletCredentials $credentials, string $playID): array
             {
                 return [
-                    'credit' => 1000.0,
+                    'credit' => 800.0,
                     'status_code' => 2100
                 ];
             }
@@ -488,7 +488,7 @@ class PcaSettleTest extends TestCase
             'externalTransactionCode' => 'b0f09415-8eec-493d-8e70-c0659b972653',
             'externalTransactionDate' => '2023-12-31 16:00:00.000',
             'balance' => [
-                'real' => '1000.00',
+                'real' => '800.00',
                 'timestamp' => '2023-12-31 16:00:00.000'
             ]
         ]);
@@ -554,11 +554,11 @@ class PcaSettleTest extends TestCase
         ];
 
         $wallet = new class extends TestWallet {
-            public function WagerAndPayout(IWalletCredentials $credentials, string $playID, string $currency, string $wagerTransactionID, float $wagerAmount, string $payoutTransactionID, float $payoutAmount, Report $report): array
+            public function Balance(IWalletCredentials $credentials, string $playID): array
             {
                 return [
-                    'credit_after' => 1010.0,
-                    'status_code' => 2102
+                    'credit' => 800.0,
+                    'status_code' => 2100
                 ];
             }
         };
@@ -574,7 +574,7 @@ class PcaSettleTest extends TestCase
             'externalTransactionCode' => '8366794157',
             'externalTransactionDate' => '2024-01-01 00:00:00.000',
             'balance' => [
-                'real' => '1010.00',
+                'real' => '800.00',
                 'timestamp' => '2024-01-01 00:00:00.000'
             ]
         ]);

--- a/Pca/tests/Unit/PcaControllerTest.php
+++ b/Pca/tests/Unit/PcaControllerTest.php
@@ -657,9 +657,9 @@ class PcaControllerTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'gameRoundCode' => 'testGameRoundCode',
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         unset($request[$unset]);
@@ -675,9 +675,9 @@ class PcaControllerTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'gameRoundCode' => 'testGameRoundCode',
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         $request[$key] = 34561;
@@ -710,10 +710,10 @@ class PcaControllerTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => $payDetails,
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         if (isset($request[$unset]) === true)
@@ -741,10 +741,10 @@ class PcaControllerTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => $payDetails,
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         if (isset($request[$key]) === true)
@@ -776,7 +776,7 @@ class PcaControllerTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -785,7 +785,7 @@ class PcaControllerTest extends TestCase
                 'amount' => '10',
                 'type' => 'WIN'
             ],
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         $mockProviderService = $this->createMock(PcaService::class);
@@ -813,10 +813,10 @@ class PcaControllerTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => $payDetails,
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         if (isset($request[$unset]) === true)
@@ -845,10 +845,10 @@ class PcaControllerTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => $payDetails,
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         if (isset($request[$key]) === true)
@@ -881,7 +881,7 @@ class PcaControllerTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -891,7 +891,7 @@ class PcaControllerTest extends TestCase
                 'type' => 'REFUND',
                 'relatedTransactionCode' => 'testRelatedTransactionCode'
             ],
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         $mockProviderService = $this->createMock(PcaService::class);
@@ -908,7 +908,7 @@ class PcaControllerTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -917,7 +917,7 @@ class PcaControllerTest extends TestCase
                 'amount' => '10',
                 'type' => 'WIN'
             ],
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         $stubProviderService = $this->createMock(PcaService::class);
@@ -937,7 +937,7 @@ class PcaControllerTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -946,7 +946,7 @@ class PcaControllerTest extends TestCase
                 'amount' => '10',
                 'type' => 'WIN'
             ],
-            'gameCodeName' => 'testCodeName'
+            'gameCodeName' => 'testGameCode'
         ]);
 
         $expected = new JsonResponse();

--- a/Pca/tests/Unit/PcaControllerTest.php
+++ b/Pca/tests/Unit/PcaControllerTest.php
@@ -791,7 +791,7 @@ class PcaControllerTest extends TestCase
         $mockProviderService = $this->createMock(PcaService::class);
         $mockProviderService->expects($this->once())
             ->method('settle')
-            ->with($request)
+            ->with(request: $request)
             ->willReturn(0.00);
 
         $controller = $this->makeController(service: $mockProviderService);
@@ -897,7 +897,7 @@ class PcaControllerTest extends TestCase
         $mockProviderService = $this->createMock(PcaService::class);
         $mockProviderService->expects($this->once())
             ->method('refund')
-            ->with($request)
+            ->with(request: $request)
             ->willReturn(0.00);
 
         $controller = $this->makeController(service: $mockProviderService);
@@ -927,7 +927,7 @@ class PcaControllerTest extends TestCase
         $mockResponse = $this->createMock(PcaResponse::class);
         $mockResponse->expects($this->once())
             ->method('gameRoundResult')
-            ->with($request, 0.00);
+            ->with(request: $request, balance: 0.00);
 
         $controller = $this->makeController(service: $stubProviderService, response: $mockResponse);
         $controller->gameRoundResult(request: $request);

--- a/Pca/tests/Unit/PcaServiceTest.php
+++ b/Pca/tests/Unit/PcaServiceTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Contracts\V2\IWallet;
 use App\Libraries\Randomizer;
 use Providers\Pca\PcaService;
+use Illuminate\Support\Carbon;
 use Providers\Pca\PcaRepository;
 use Providers\Pca\PcaCredentials;
 use Wallet\V1\ProvSys\Transfer\Report;
@@ -1727,24 +1728,24 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->expects($this->once())
             ->method('getPlayerByPlayID')
-            ->with('playerid')
+            ->with('testplayid')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionID')
+        $mockRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -1774,7 +1775,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
@@ -1794,7 +1795,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
@@ -1804,18 +1805,18 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_mockRepositoryWithoutWin_getTransactionByTransactionIDRefID()
+    public function test_settle_mockRepositoryWithoutWin_getTransactionByBetID()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -1824,11 +1825,11 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $mockRepository->expects($this->once())
-            ->method('getTransactionByTransactionIDRefID')
-            ->with($request->gameRoundCode, "L-{$request->requestId}")
+            ->method('getTransactionByBetID')
+            ->with("L-{$request->requestId}")
             ->willReturn(null);
 
-        $mockRepository->method('getBetTransactionByTransactionID')
+        $mockRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -1852,11 +1853,11 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_mockRepositoryWithWin_getTransactionByTransactionIDRefID()
+    public function test_settle_mockRepositoryWithWin_getTransactionByBetID()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -1869,7 +1870,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -1878,11 +1879,11 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $mockRepository->expects($this->once())
-            ->method('getTransactionByTransactionIDRefID')
-            ->with($request->gameRoundCode, $request->pay['transactionCode'])
+            ->method('getTransactionByBetID')
+            ->with($request->pay['transactionCode'])
             ->willReturn(null);
 
-        $mockRepository->method('getBetTransactionByTransactionID')
+        $mockRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -1910,14 +1911,14 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -1927,10 +1928,10 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getTransactionByTransactionIDRefID')
+        $stubRepository->method('getTransactionByBetID')
             ->willReturn((object) []);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -1954,7 +1955,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -1967,7 +1968,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -1977,7 +1978,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -1997,11 +1998,11 @@ class PcaServiceTest extends TestCase
         $this->assertSame(expected: $expected, actual: $response);
     }
 
-    public function test_settle_mockRepository_getBetTransactionByTransactionID()
+    public function test_settle_mockRepository_getBetTransactionByRefID()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2014,7 +2015,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2023,7 +2024,7 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $mockRepository->expects($this->once())
-            ->method('getBetTransactionByTransactionID')
+            ->method('getBetTransactionByRefID')
             ->with($request->gameRoundCode)
             ->willReturn((object) []);
 
@@ -2054,14 +2055,14 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2069,7 +2070,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn(null);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2087,18 +2088,20 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_mockRepository_createLoseTransaction()
+    public function test_settle_mockRepositoryWithWithoutWin_createTransaction()
     {
+        Carbon::setTestNow('2024-01-01 00:00:01');
+
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2106,12 +2109,22 @@ class PcaServiceTest extends TestCase
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionID')
+        $mockRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $mockRepository->expects($this->once())
-            ->method('createLoseTransaction')
-            ->with($player, $request);
+            ->method('createTransaction')
+            ->with(
+                playID: 'testplayid',
+                currency: 'IDR',
+                gameCode: 'testGameCode',
+                betID: 'L-TEST_requestToken',
+                betAmount: 0,
+                winAmount: 0,
+                betTime: '2024-01-01 00:00:01',
+                status: 'PAYOUT',
+                refID: 'testGameRoundCode'
+            );
 
         $stubReport = $this->createMock(WalletReport::class);
         $stubReport->method('makeCasinoReport')
@@ -2138,14 +2151,14 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2153,7 +2166,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2192,14 +2205,14 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2207,7 +2220,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2225,7 +2238,7 @@ class PcaServiceTest extends TestCase
             ->method('balance')
             ->with(
                 $providerCredentials,
-                'playerid'
+                'testplayid'
             )
             ->willReturn([
                 'status_code' => 2100,
@@ -2254,14 +2267,14 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'gameCodeName' => 'testGameCode'
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2269,7 +2282,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2298,11 +2311,11 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_mockRepository_createSettleTransaction()
+    public function test_settle_mockRepositoryWithWin_createTransaction()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2315,7 +2328,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2323,15 +2336,21 @@ class PcaServiceTest extends TestCase
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionID')
+        $mockRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $mockRepository->expects($this->once())
-            ->method('createSettleTransaction')
+            ->method('createTransaction')
             ->with(
-                $player,
-                $request,
-                '2024-01-01 08:00:03',
+                playID: 'testplayid',
+                currency: 'IDR',
+                gameCode: 'testGameCode',
+                betID: 'testTransactionCode',
+                betAmount: 0,
+                winAmount: 10,
+                betTime: '2024-01-01 08:00:03',
+                status: 'PAYOUT',
+                refID: 'testGameRoundCode'
             );
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2359,7 +2378,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2372,7 +2391,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2380,7 +2399,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $mockCredentials = $this->createMock(PcaCredentials::class);
@@ -2419,7 +2438,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2432,7 +2451,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2440,7 +2459,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $providerCredentials = $this->createMock(ICredentials::class);
@@ -2488,7 +2507,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2501,7 +2520,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2509,7 +2528,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $providerCredentials = $this->createMock(ICredentials::class);
@@ -2562,7 +2581,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2575,7 +2594,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2583,7 +2602,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2615,7 +2634,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2628,7 +2647,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2638,7 +2657,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionID')
+        $stubRepository->method('getBetTransactionByRefID')
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2669,11 +2688,11 @@ class PcaServiceTest extends TestCase
         $this->assertSame(expected: $expected, actual: $response);
     }
 
-    public function test_refund_stubRepository_getPlayerByPlayID()
+    public function test_refund_mockRepository_getPlayerByPlayID()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2687,7 +2706,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2703,10 +2722,10 @@ class PcaServiceTest extends TestCase
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->expects($this->once())
             ->method('getPlayerByPlayID')
-            ->with('playerid')
+            ->with('testplayid')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionIDRefID')
+        $mockRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $stubWallet = $this->createMock(IWallet::class);
@@ -2726,7 +2745,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2753,7 +2772,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2770,11 +2789,11 @@ class PcaServiceTest extends TestCase
         $service->refund($request);
     }
 
-    public function test_refund_mockRepository_getBetTransactionByTransactionIDRefID()
+    public function test_refund_mockRepository_getBetTransactionByBetID()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2788,7 +2807,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2806,8 +2825,8 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $mockRepository->expects($this->once())
-            ->method('getBetTransactionByTransactionIDRefID')
-            ->with($request->gameRoundCode)
+            ->method('getBetTransactionByBetID')
+            ->with($request->pay['relatedTransactionCode'])
             ->willReturn($betTransaction);
 
         $stubWallet = $this->createMock(IWallet::class);
@@ -2827,7 +2846,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2841,7 +2860,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2849,18 +2868,18 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionIDRefID')
+        $stubRepository->method('getBetTransactionByBetID')
             ->willReturn(null);
 
         $service = $this->makeService(repository: $stubRepository);
         $service->refund(request: $request);
     }
 
-    public function test_refund_mockRepository_getRefundTransactionByTransactionIDRefID()
+    public function test_refund_mockRepository_getTransactionByRefID()
     {
         $request = new Request([
             'requestId' => 'test_requestToken',
-            'username' => 'test_playerID',
+            'username' => 'test_TESTPLAYID',
             'externalToken' => 'test_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2874,7 +2893,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerID',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2891,12 +2910,12 @@ class PcaServiceTest extends TestCase
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionIDRefID')
+        $mockRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $mockRepository->expects($this->once())
-            ->method('getRefundTransactionByTransactionIDRefID')
-            ->with($request->gameRoundCode, $request->pay['relatedTransactionCode'])
+            ->method('getTransactionByRefID')
+            ->with($request->pay['relatedTransactionCode'])
             ->willReturn(null);
 
         $stubWallet = $this->createMock(IWallet::class);
@@ -2914,7 +2933,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -2928,7 +2947,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2947,7 +2966,7 @@ class PcaServiceTest extends TestCase
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionIDRefID')
+        $mockRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $stubWallet = $this->createMock(IWallet::class);
@@ -2963,16 +2982,16 @@ class PcaServiceTest extends TestCase
         $this->assertSame(expected: $expected, actual: $response);
     }
 
-    public function test_refund_mockRepository_createRefundTransaction()
+    public function test_refund_mockRepository_createTransaction()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
                 'transactionCode' => 'testTransactionCode',
-                'transactionDate' => '2024-01-01 00:00:00.000',
+                'transactionDate' => '2024-01-01 00:00:01.000',
                 'amount' => '10',
                 'type' => 'REFUND',
                 'relatedTransactionCode' => 'testRelatedTransactionCode'
@@ -2981,7 +3000,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -2998,15 +3017,21 @@ class PcaServiceTest extends TestCase
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $mockRepository->method('getBetTransactionByTransactionIDRefID')
+        $mockRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $mockRepository->expects($this->once())
-            ->method('createRefundTransaction')
+            ->method('createTransaction')
             ->with(
-                $player,
-                $request,
-                '2024-01-01 08:00:00'
+                playID: 'testplayid',
+                currency: 'IDR',
+                gameCode: 'testGameCode',
+                betID: 'testTransactionCode',
+                betAmount: 10.0,
+                winAmount: 10.0,
+                betTime: '2024-01-01 08:00:01',
+                status: 'REFUND',
+                refID: 'testRelatedTransactionCode'
             );
 
         $stubWallet = $this->createMock(IWallet::class);
@@ -3024,7 +3049,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -3038,7 +3063,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -3055,7 +3080,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionIDRefID')
+        $stubRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $mockCredentials = $this->createMock(PcaCredentials::class);
@@ -3075,11 +3100,11 @@ class PcaServiceTest extends TestCase
         $service->refund(request: $request);
     }
 
-    public function test_refund_mockWallet_resettle()
+    public function test_refund_mockWallet_wagerAndPayout()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -3093,7 +3118,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -3110,7 +3135,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionIDRefID')
+        $stubRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $providerCredentials = $this->createMock(ICredentials::class);
@@ -3126,10 +3151,10 @@ class PcaServiceTest extends TestCase
                 credentials: $providerCredentials,
                 playID: $player->play_id,
                 currency: $player->currency,
-                transactionID: "resettle-{$betTransaction->ref_id}",
+                transactionID: "resettle-testTransactionCode",
                 amount: (float) $request->pay['amount'],
-                betID: $betTransaction->ref_id,
-                settledTransactionID: "wager-{$betTransaction->ref_id}",
+                betID: 'testTransactionCode',
+                settledTransactionID: "wager-testTransactionCode",
                 betTime: '2024-01-01 08:00:00'
             )
             ->willReturn([
@@ -3148,7 +3173,7 @@ class PcaServiceTest extends TestCase
 
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -3162,7 +3187,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -3179,7 +3204,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionIDRefID')
+        $stubRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $stubWallet = $this->createMock(IWallet::class);
@@ -3197,7 +3222,7 @@ class PcaServiceTest extends TestCase
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_PLAYERID',
+            'username' => 'TEST_TESTPLAYID',
             'externalToken' => 'TEST_authToken',
             'gameRoundCode' => 'testGameRoundCode',
             'pay' => [
@@ -3211,7 +3236,7 @@ class PcaServiceTest extends TestCase
         ]);
 
         $player = (object) [
-            'play_id' => 'playerid',
+            'play_id' => 'testplayid',
             'currency' => 'IDR'
         ];
 
@@ -3230,7 +3255,7 @@ class PcaServiceTest extends TestCase
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
-        $stubRepository->method('getBetTransactionByTransactionIDRefID')
+        $stubRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
         $stubWallet = $this->createMock(IWallet::class);

--- a/Pca/tests/Unit/PcaServiceTest.php
+++ b/Pca/tests/Unit/PcaServiceTest.php
@@ -1907,7 +1907,7 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_transactionAlreadyExistsWithoutWin_expected()
+    public function test_settle_transactionAlreadyExists_expected()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
@@ -1943,53 +1943,6 @@ class PcaServiceTest extends TestCase
             ->willReturn([
                 'status_code' => 2100,
                 'credit' => $expected
-            ]);
-
-        $service = $this->makeService(repository: $stubRepository, wallet: $stubWallet, report: $stubReport);
-        $response = $service->settle($request);
-
-        $this->assertSame(expected: $expected, actual: $response);
-    }
-
-    public function test_settle_transactionAlreadyExistsWithWin_expected()
-    {
-        $request = new Request([
-            'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_TESTPLAYID',
-            'externalToken' => 'TEST_authToken',
-            'gameRoundCode' => 'testGameRoundCode',
-            'pay' => [
-                'transactionCode' => 'testTransactionCode',
-                'transactionDate' => '2024-01-01 00:00:03.000',
-                'amount' => '10',
-                'type' => 'WIN'
-            ],
-            'gameCodeName' => 'testGameCode'
-        ]);
-
-        $player = (object) [
-            'play_id' => 'testplayid',
-            'currency' => 'IDR'
-        ];
-
-        $expected = 990.00;
-
-        $stubRepository = $this->createMock(PcaRepository::class);
-        $stubRepository->method('getPlayerByPlayID')
-            ->willReturn($player);
-
-        $stubRepository->method('getBetTransactionByRefID')
-            ->willReturn((object) []);
-
-        $stubReport = $this->createMock(WalletReport::class);
-        $stubReport->method('makeCasinoReport')
-            ->willReturn(new Report);
-
-        $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('wagerAndPayout')
-            ->willReturn([
-                'status_code' => 2100,
-                'credit_after' => $expected
             ]);
 
         $service = $this->makeService(repository: $stubRepository, wallet: $stubWallet, report: $stubReport);
@@ -2929,7 +2882,7 @@ class PcaServiceTest extends TestCase
         $service->refund(request: $request);
     }
 
-    public function test_refund_transactionAlreadySettled_TransactionAlreadyExistsException()
+    public function test_refund_transactionAlreadyRefunded_expected()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
@@ -2969,10 +2922,13 @@ class PcaServiceTest extends TestCase
         $mockRepository->method('getBetTransactionByBetID')
             ->willReturn($betTransaction);
 
+        $mockRepository->method('getTransactionByRefID')
+            ->willReturn((object) []);
+
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('balance')
             ->willReturn([
-                'credit_after' => $expected,
+                'credit' => $expected,
                 'status_code' => 2100
             ]);
 

--- a/Pca/tests/Unit/PcaServiceTest.php
+++ b/Pca/tests/Unit/PcaServiceTest.php
@@ -1797,7 +1797,7 @@ class PcaServiceTest extends TestCase
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->expects($this->once())
             ->method('getPlayerByPlayID')
-            ->with('testplayid')
+            ->with(playID: 'testplayid')
             ->willReturn($player);
 
         $mockRepository->method('getBetTransactionByRefID')
@@ -1881,7 +1881,7 @@ class PcaServiceTest extends TestCase
 
         $mockRepository->expects($this->once())
             ->method('getTransactionByBetID')
-            ->with("L-{$request->requestId}")
+            ->with(betID: "L-{$request->requestId}")
             ->willReturn(null);
 
         $mockRepository->method('getBetTransactionByRefID')
@@ -1935,7 +1935,7 @@ class PcaServiceTest extends TestCase
 
         $mockRepository->expects($this->once())
             ->method('getTransactionByBetID')
-            ->with($request->pay['transactionCode'])
+            ->with(betID: $request->pay['transactionCode'])
             ->willReturn(null);
 
         $mockRepository->method('getBetTransactionByRefID')
@@ -2033,7 +2033,7 @@ class PcaServiceTest extends TestCase
 
         $mockRepository->expects($this->once())
             ->method('getBetTransactionByRefID')
-            ->with($request->gameRoundCode)
+            ->with(refID: $request->gameRoundCode)
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2155,7 +2155,7 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_mockCredentialsBalance_getCredentialsByCurrency()
+    public function test_settle_mockCredentials_getCredentialsByCurrency()
     {
         $request = new Request([
             'requestId' => 'TEST_requestToken',
@@ -2184,7 +2184,7 @@ class PcaServiceTest extends TestCase
         $mockCredentials = $this->createMock(PcaCredentials::class);
         $mockCredentials->expects($this->once())
             ->method('getCredentialsByCurrency')
-            ->with($player->currency);
+            ->with(currency: $player->currency);
 
         $stubWallet = $this->createMock(IWallet::class);
         $stubWallet->method('balance')
@@ -2245,8 +2245,8 @@ class PcaServiceTest extends TestCase
         $mockWallet->expects($this->once())
             ->method('balance')
             ->with(
-                $providerCredentials,
-                'testplayid'
+                credentials: $providerCredentials,
+                playID: 'testplayid'
             )
             ->willReturn([
                 'status_code' => 2100,
@@ -2382,66 +2382,6 @@ class PcaServiceTest extends TestCase
         $service->settle($request);
     }
 
-    public function test_settle_mockCredentialsWagerAndPayout_getCredentialsByCurrency()
-    {
-        $request = new Request([
-            'requestId' => 'TEST_requestToken',
-            'username' => 'TEST_TESTPLAYID',
-            'externalToken' => 'TEST_authToken',
-            'gameRoundCode' => 'testGameRoundCode',
-            'pay' => [
-                'transactionCode' => 'testTransactionCode',
-                'transactionDate' => '2024-01-01 00:00:03.000',
-                'amount' => '10',
-                'type' => 'WIN'
-            ],
-            'gameCodeName' => 'testGameCode'
-        ]);
-
-        $player = (object) [
-            'play_id' => 'testplayid',
-            'currency' => 'IDR'
-        ];
-
-        $stubRepository = $this->createMock(PcaRepository::class);
-        $stubRepository->method('getPlayerByPlayID')
-            ->willReturn($player);
-
-        $stubRepository->method('getBetTransactionByRefID')
-            ->willReturn((object) []);
-
-        $mockCredentials = $this->createMock(PcaCredentials::class);
-        $mockCredentials->expects($this->once())
-            ->method('getCredentialsByCurrency')
-            ->with($player->currency);
-
-        $stubReport = $this->createMock(WalletReport::class);
-        $stubReport->method('makeCasinoReport')
-            ->willReturn(new Report);
-
-        $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('balance')
-            ->willReturn([
-                'status_code' => 2100,
-                'credit' => 0.00
-            ]);
-
-        $stubWallet->method('WagerAndPayout')
-            ->willReturn([
-                'status_code' => 2100,
-                'credit_after' => 0.00
-            ]);
-
-        $service = $this->makeService(
-            repository: $stubRepository,
-            credentials: $mockCredentials,
-            wallet: $stubWallet,
-            report: $stubReport
-        );
-
-        $service->settle($request);
-    }
-
     public function test_settle_mockReport_makeCasinoReport()
     {
         $request = new Request([
@@ -2559,14 +2499,14 @@ class PcaServiceTest extends TestCase
         $mockWallet->expects($this->once())
             ->method('WagerAndPayout')
             ->with(
-                $providerCredentials,
-                $player->play_id,
-                $player->currency,
-                "wagerPayout-{$request->pay['transactionCode']}",
-                0,
-                "wagerPayout-{$request->pay['transactionCode']}",
-                (float) $request->pay['amount'],
-                new Report
+                credentials: $providerCredentials,
+                playID: $player->play_id,
+                currency: $player->currency,
+                wagerTransactionID: "wagerPayout-{$request->pay['transactionCode']}",
+                wagerAmount: 0,
+                payoutTransactionID: "wagerPayout-{$request->pay['transactionCode']}",
+                payoutAmount: (float) $request->pay['amount'],
+                report: new Report
             )
             ->willReturn([
                 'status_code' => 2100,
@@ -2721,7 +2661,7 @@ class PcaServiceTest extends TestCase
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->expects($this->once())
             ->method('getPlayerByPlayID')
-            ->with('testplayid')
+            ->with(playID: 'testplayid')
             ->willReturn($player);
 
         $mockRepository->method('getBetTransactionByBetID')
@@ -2820,7 +2760,7 @@ class PcaServiceTest extends TestCase
 
         $mockRepository->expects($this->once())
             ->method('getBetTransactionByBetID')
-            ->with($request->pay['relatedTransactionCode'])
+            ->with(betID: $request->pay['relatedTransactionCode'])
             ->willReturn((object) []);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -2904,7 +2844,7 @@ class PcaServiceTest extends TestCase
 
         $mockRepository->expects($this->once())
             ->method('getTransactionByRefID')
-            ->with($request->pay['relatedTransactionCode'])
+            ->with(refID: $request->pay['relatedTransactionCode'])
             ->willReturn(null);
 
         $stubReport = $this->createMock(WalletReport::class);
@@ -3059,7 +2999,7 @@ class PcaServiceTest extends TestCase
         $mockCredentials = $this->createMock(PcaCredentials::class);
         $mockCredentials->expects($this->once())
             ->method('getCredentialsByCurrency')
-            ->with($player->currency);
+            ->with(currency: $player->currency);
 
         $stubReport = $this->createMock(WalletReport::class);
         $stubReport->method('makeCasinoReport')
@@ -3077,6 +3017,63 @@ class PcaServiceTest extends TestCase
             credentials: $mockCredentials,
             wallet: $stubWallet,
             report: $stubReport
+        );
+
+        $service->refund(request: $request);
+    }
+
+    public function test_refund_mockReport_makeCasinoReport()
+    {
+        $request = new Request([
+            'requestId' => 'TEST_requestToken',
+            'username' => 'TEST_TESTPLAYID',
+            'externalToken' => 'TEST_authToken',
+            'gameRoundCode' => 'testGameRoundCode',
+            'pay' => [
+                'transactionCode' => 'testTransactionCode',
+                'transactionDate' => '2024-01-01 00:00:00.000',
+                'amount' => '10',
+                'type' => 'REFUND',
+                'relatedTransactionCode' => 'testRelatedTransactionCode'
+            ],
+            'gameCodeName' => 'testGameCode'
+        ]);
+
+        $player = (object) [
+            'play_id' => 'testplayid',
+            'currency' => 'IDR'
+        ];
+
+        $stubRepository = $this->createMock(PcaRepository::class);
+        $stubRepository->method('getPlayerByPlayID')
+            ->willReturn($player);
+
+        $stubRepository->method('getBetTransactionByBetID')
+            ->willReturn((object) []);
+
+        $mockReport = $this->createMock(WalletReport::class);
+        $mockReport->expects($this->once())
+            ->method('makeCasinoReport')
+            ->with(
+                trxID: 'testTransactionCode',
+                gameCode: 'testGameCode',
+                betTime: '2024-01-01 08:00:00',
+                betChoice: '-',
+                result: '-'
+            )
+            ->willReturn(new Report);
+
+        $stubWallet = $this->createMock(IWallet::class);
+        $stubWallet->method('WagerAndPayout')
+            ->willReturn([
+                'credit_after' => 10.00,
+                'status_code' => 2100
+            ]);
+
+        $service = $this->makeService(
+            repository: $stubRepository,
+            wallet: $stubWallet,
+            report: $mockReport
         );
 
         $service->refund(request: $request);

--- a/Pca/tests/Unit/PcaServiceTest.php
+++ b/Pca/tests/Unit/PcaServiceTest.php
@@ -2718,15 +2718,6 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->expects($this->once())
             ->method('getPlayerByPlayID')
@@ -2734,16 +2725,20 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $mockRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
+
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
 
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'credit_after' => 10.00,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet);
+        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet, report: $stubReport);
         $service->refund(request: $request);
     }
 
@@ -2819,15 +2814,6 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
@@ -2835,16 +2821,20 @@ class PcaServiceTest extends TestCase
         $mockRepository->expects($this->once())
             ->method('getBetTransactionByBetID')
             ->with($request->pay['relatedTransactionCode'])
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
+
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
 
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'credit_after' => 10.00,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet);
+        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet, report: $stubReport);
         $service->refund(request: $request);
     }
 
@@ -2905,35 +2895,30 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
         $mockRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
 
         $mockRepository->expects($this->once())
             ->method('getTransactionByRefID')
             ->with($request->pay['relatedTransactionCode'])
             ->willReturn(null);
 
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
+
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'credit_after' => 10.00,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet);
+        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet, report: $stubReport);
         $service->refund(request: $request);
     }
 
@@ -2959,15 +2944,6 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $expected = 100.00;
 
         $mockRepository = $this->createMock(PcaRepository::class);
@@ -2975,7 +2951,7 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $mockRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
 
         $mockRepository->method('getTransactionByRefID')
             ->willReturn((object) []);
@@ -3015,21 +2991,12 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $mockRepository = $this->createMock(PcaRepository::class);
         $mockRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
         $mockRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
 
         $mockRepository->expects($this->once())
             ->method('createTransaction')
@@ -3045,14 +3012,18 @@ class PcaServiceTest extends TestCase
                 refID: 'testRelatedTransactionCode'
             );
 
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
+
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'credit_after' => 10.00,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet);
+        $service = $this->makeService(repository: $mockRepository, wallet: $stubWallet, report: $stubReport);
         $service->refund(request: $request);
     }
 
@@ -3078,35 +3049,35 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $stubRepository = $this->createMock(PcaRepository::class);
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
         $stubRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
 
         $mockCredentials = $this->createMock(PcaCredentials::class);
         $mockCredentials->expects($this->once())
             ->method('getCredentialsByCurrency')
             ->with($player->currency);
 
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
+
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'credit_after' => 10.00,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $stubRepository, credentials: $mockCredentials, wallet: $stubWallet);
+        $service = $this->makeService(
+            repository: $stubRepository,
+            credentials: $mockCredentials,
+            wallet: $stubWallet,
+            report: $stubReport
+        );
 
         $service->refund(request: $request);
     }
@@ -3133,21 +3104,12 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 08:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $stubRepository = $this->createMock(PcaRepository::class);
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
         $stubRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
 
         $providerCredentials = $this->createMock(ICredentials::class);
 
@@ -3155,25 +3117,34 @@ class PcaServiceTest extends TestCase
         $stubCredentials->method('getCredentialsByCurrency')
             ->willReturn($providerCredentials);
 
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
+
         $stubWallet = $this->createMock(IWallet::class);
         $stubWallet->expects($this->once())
-            ->method('resettle')
+            ->method('WagerAndPayout')
             ->with(
                 credentials: $providerCredentials,
-                playID: $player->play_id,
-                currency: $player->currency,
-                transactionID: "resettle-testTransactionCode",
-                amount: (float) $request->pay['amount'],
-                betID: 'testTransactionCode',
-                settledTransactionID: "wager-testTransactionCode",
-                betTime: '2024-01-01 08:00:00'
+                playID: 'testplayid',
+                currency: 'IDR',
+                wagerTransactionID: "wagerPayout-testTransactionCode",
+                wagerAmount: 0,
+                payoutTransactionID: "wagerPayout-testTransactionCode",
+                payoutAmount: (float) $request->pay['amount'],
+                report: new Report
             )
             ->willReturn([
                 'credit_after' => 10.00,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $stubRepository, credentials: $stubCredentials, wallet: $stubWallet);
+        $service = $this->makeService(
+            repository: $stubRepository,
+            credentials: $stubCredentials,
+            wallet: $stubWallet,
+            report: $stubReport
+        );
 
         $service->refund(request: $request);
     }
@@ -3202,29 +3173,24 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $stubRepository = $this->createMock(PcaRepository::class);
         $stubRepository->method('getPlayerByPlayID')
             ->willReturn($player);
 
         $stubRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
+
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
 
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'status_code' => 9999
             ]);
 
-        $service = $this->makeService(repository: $stubRepository, wallet: $stubWallet);
+        $service = $this->makeService(repository: $stubRepository, wallet: $stubWallet, report: $stubReport);
 
         $service->refund(request: $request);
     }
@@ -3251,15 +3217,6 @@ class PcaServiceTest extends TestCase
             'currency' => 'IDR'
         ];
 
-        $betTransaction = (object) [
-            'trx_id' => 'testGameRoundCode',
-            'bet_amount' => 10,
-            'win_amount' => 0,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => null,
-            'ref_id' => 'testRelatedTransactionCode'
-        ];
-
         $expected = 10.00;
 
         $stubRepository = $this->createMock(PcaRepository::class);
@@ -3267,16 +3224,20 @@ class PcaServiceTest extends TestCase
             ->willReturn($player);
 
         $stubRepository->method('getBetTransactionByBetID')
-            ->willReturn($betTransaction);
+            ->willReturn((object) []);
+
+        $stubReport = $this->createMock(WalletReport::class);
+        $stubReport->method('makeCasinoReport')
+            ->willReturn(new Report);
 
         $stubWallet = $this->createMock(IWallet::class);
-        $stubWallet->method('resettle')
+        $stubWallet->method('WagerAndPayout')
             ->willReturn([
                 'credit_after' => $expected,
                 'status_code' => 2100
             ]);
 
-        $service = $this->makeService(repository: $stubRepository, wallet: $stubWallet);
+        $service = $this->makeService(repository: $stubRepository, wallet: $stubWallet, report: $stubReport);
 
         $response = $service->refund(request: $request);
 


### PR DESCRIPTION
- If transactionCode exists, just return current player balance
- Create DB record
- Use transactionCode as bet_id, and gameRoundCode as ref_id
- For refund transaction, use relatedTransactionCode as ref_id, and transactionCode as trx_id
- use wagerAndPayout wallet method for refund scenario
- Fix and Adjust Tests